### PR TITLE
Hook up simulation code to UI & HTTP server

### DIFF
--- a/objiotracing/cmd/server/main.go
+++ b/objiotracing/cmd/server/main.go
@@ -44,12 +44,14 @@ type PlotTraceResponse struct {
 	CacheHitMBPSL5L6 []float64 `json:"cache_hit_mbps_l5_l6"`
 }
 
-const targetTicks = 10000
 
+// TODO(josh): Produce a hit rate graph, to compare hit rate of productionized
+// pebble block clock to simulated algorithms.
 func Plot(req PlotTraceRequest) PlotTraceResponse {
 	md, it, err := lib.Load(req.Trace)
 	checkErr(err, fmt.Sprintf("loading trace %q", req.Trace))
 
+	const targetTicks = 10000
 	tickSecs := md.DurationSecs / targetTicks
 	if tickSecs < 1 {
 		tickSecs = 1
@@ -132,6 +134,92 @@ func Plot(req PlotTraceRequest) PlotTraceResponse {
 	return r
 }
 
+type SimulateTraceRequest struct {
+	Trace string `json:"trace"`
+}
+
+// TODO(josh): Consider returning a set of points to graph instead.
+type SimulateTraceResponse struct {
+	CacheSize []int `json:"cache_size"`
+	Results   []ResultsPerReplacementPolicy `json:"results_per_replacement_policy"`
+}
+
+type ResultsPerReplacementPolicy struct {
+	ReplacementPolicy string `json:"replacement_policy"`
+	Results           []ResultsPerOptionSet `json:"results_per_option_set"`
+}
+
+type ResultsPerOptionSet struct {
+	OptionSet string `json:"option_set"`
+	HitRate   []float64 `json:"hit_rate"`
+}
+
+var configs = []lib.Config{
+	{},
+	{
+		WriteThru: true,
+	},
+	{
+		L5AndL6Only: true,
+	},
+	{
+		CacheUserFacingReadsOnly: true,
+	},
+	{
+		WriteThru: true,
+		L5AndL6Only: true,
+		CacheUserFacingReadsOnly: true,
+	},
+}
+
+// TODO(josh): Enable varying block size.
+// TODO(josh): Enable measure hit rate over time.
+func Simulate(req SimulateTraceRequest) SimulateTraceResponse {
+	const (
+		start = 1024      // 1K
+		end = 1024 * 1000 // 1MB
+		targetTicks = 10
+		increment = (end - start) / targetTicks
+	)
+
+	resp := SimulateTraceResponse{}
+	for cacheSize := start; cacheSize < end; cacheSize += increment {
+		resp.CacheSize = append(resp.CacheSize, cacheSize)
+	}
+	for i, policy := range []lib.ReplacementPolicy{lib.TinyLFU, lib.ClockPro, lib.S4LRU} {
+		resp.Results = append(resp.Results, ResultsPerReplacementPolicy{
+			ReplacementPolicy: policy.String(),
+		})
+		for j, config := range configs {
+			config.Policy = policy
+			resp.Results[i].Results = append(resp.Results[i].Results, ResultsPerOptionSet{
+				OptionSet: config.String(),
+			})
+			for cacheSize := start; cacheSize < end; cacheSize += increment {
+				config.CacheSize = cacheSize
+				if policy == lib.TinyLFU {
+					config.TinyLFUSamples = 10 * config.CacheSize
+				}
+				func() {
+					log.Printf("simulate %s / %v / %s / %s\n", req.Trace, cacheSize, policy.String(), config.String())
+
+					_, it, err := lib.Load(req.Trace)
+					checkErr(err, fmt.Sprintf("loading trace %q", req.Trace))
+					defer it.Close()
+
+					results, err := lib.Simulate(req.Trace, it, config)
+					checkErr(err, fmt.Sprintf("calling simulate %q", req.Trace))
+					hitRate := float64(results.Hits) / float64(results.Hits + results.Misses)
+
+					resp.Results[i].Results[j].HitRate = append(resp.Results[i].Results[j].HitRate, hitRate)
+				}()
+			}
+		}
+	}
+
+	return resp
+}
+
 func main() {
 	http.HandleFunc("/list", func(w http.ResponseWriter, r *http.Request) {
 		log.Printf("list\n")
@@ -152,6 +240,21 @@ func main() {
 		checkErr(json.Unmarshal(reqBuf, &req), "unmarshalling request")
 		log.Printf("plot %s\n", req.Trace)
 		res := Plot(req)
+
+		respBuf, err := json.Marshal(&res)
+		checkErr(err, "marshalling response")
+		_, _ = w.Write(respBuf)
+	})
+
+	http.HandleFunc("/simulate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("Access-Control-Allow-Origin", "*")
+
+		reqBuf, err := io.ReadAll(r.Body)
+		checkErr(err, "reading body")
+		var req SimulateTraceRequest
+		checkErr(json.Unmarshal(reqBuf, &req), "unmarshalling request")
+		log.Printf("simulate %s\n", req.Trace)
+		res := Simulate(req)
 
 		respBuf, err := json.Marshal(&res)
 		checkErr(err, "marshalling response")

--- a/objiotracing/index.html
+++ b/objiotracing/index.html
@@ -59,6 +59,15 @@
 <div id="trace_plot_div">
 </div>
 
+<div id="simulate_plot_div1">
+</div>
+
+<div id="simulate_plot_div2">
+</div>
+
+<div id="simulate_plot_div3">
+</div>
+
 <script>
     let dropdown = document.getElementById("traces_dropdown");
     $.get("http://localhost:8089/list", function (data) {
@@ -71,27 +80,55 @@
         })
     })
 
-    var plot = null;
-    var plotDiv = document.getElementById("trace_plot_div")
+    var tracePlot = null;
+    var tracePlotDiv = document.getElementById("trace_plot_div")
+
+    var simulatePlots = [null, null, null]
+    var simulatePlotDivs = [
+        document.getElementById("simulate_plot_div1"),
+        document.getElementById("simulate_plot_div2"),
+        document.getElementById("simulate_plot_div3"),
+        ]
 
     dropdown.onchange = function() {
-        if (plot) {
-            plot.destroy();
-            plot = null;
+        if (tracePlot) {
+            tracePlot.destroy();
+            tracePlot = null;
         }
-        while (plotDiv.firstChild) {
-            plotDiv.removeChild(plotDiv.firstChild);
+        while (tracePlotDiv.firstChild) {
+            tracePlotDiv.removeChild(tracePlotDiv.firstChild);
         }
+
+        simulatePlots.forEach(function(plot) {
+            if (plot) {
+                plot.destroy()
+                plot = null
+            }
+        })
+        simulatePlotDivs.forEach(function(div) {
+            while (div.firstChild) {
+                div.removeChild(div.firstChild);
+            }
+        })
+
         if (dropdown.value == "") {
             return;
         }
+
         let p = document.createElement("p");
-        p.innerHTML = 'Generating plot...';
-        plotDiv.append(p)
+        p.innerHTML = 'Generating...';
+        tracePlotDiv.append(p)
+
+        simulatePlotDivs.forEach(function(div) {
+            let p = document.createElement("p");
+            p.innerHTML = 'Generating...';
+            div.append(p)
+        })
+
         $.post("http://localhost:8089/plot", JSON.stringify({ trace: dropdown.value }), function (respData) {
             let res = JSON.parse(respData);
             let opts = {
-                title: dropdown.value,
+                title: "IO stats",
                 width: 1200,
                 height: 600,
                 axes: [
@@ -147,8 +184,59 @@
                 res.cache_hit_mbps_l5_l6,
             ];
 
-            plotDiv.removeChild(plotDiv.firstChild)
-            plot = new uPlot(opts, data, plotDiv)
+            tracePlotDiv.removeChild(tracePlotDiv.firstChild)
+            tracePlot = new uPlot(opts, data, tracePlotDiv)
+        })
+
+        $.post("http://localhost:8089/simulate", JSON.stringify({ trace: dropdown.value }), function (respData) {
+            let rgb = [
+                "rgb(255,0,0)",
+                "rgb(0,0,255)",
+                "rgb(0,255,0)",
+                "rgb(128,30,30)",
+                "rgb(30,30,128)",
+                "rgb(30,128,30)",
+            ];
+            let res = JSON.parse(respData);
+            let i = 0
+            res.results_per_replacement_policy.forEach(function(perPolicy) {
+                let opts = {
+                    title: dropdown.value,
+                    width: 1200,
+                    height: 600,
+                    axes: [
+                        {},
+                        {
+                            label: "hit rate",
+                        }
+                    ],
+                    series: [
+                        {},
+                    ],
+                    scales: {
+                        x: {
+                            time: false,
+                        }
+                    }
+                };
+                let data = [
+                    res.cache_size,
+                ];
+                let j = 0
+                perPolicy.results_per_option_set.forEach(function(perOptionSet) {
+                    opts.series.push({
+                        label: perOptionSet.option_set,
+                        stroke: rgb[j],
+                        value: (u, v) => v == null ? null : v.toFixed(2) + "%",
+                    })
+                    data.push(perOptionSet.hit_rate)
+                    j++
+                })
+                opts.title = perPolicy.replacement_policy
+                simulatePlotDivs[i].removeChild(simulatePlotDivs[i].firstChild)
+                simulatePlots[i] = new uPlot(opts, data, simulatePlotDivs[i])
+                i++
+            })
         })
     }
 </script>

--- a/objiotracing/lib/simulate.go
+++ b/objiotracing/lib/simulate.go
@@ -15,24 +15,44 @@ const (
 	ClockPro ReplacementPolicy = iota
 	S4LRU
 	TinyLFU
-	// TODO(josh): Implement.
+	// TODO(josh): Implement. Can use https://github.com/dgryski/go-tinylfu/blob/master/lru.go.
 	LRU
 )
 
+func (p ReplacementPolicy) String() string {
+	if p == ClockPro {
+		return "ClockPro"
+	} else if p == S4LRU {
+		return "S4LRU"
+	} else if p == TinyLFU {
+		return  "TinyLFU"
+	} else if p == LRU {
+		return "LRU"
+	} else {
+		panic("not implemented")
+	}
+}
+
+// Note that this is used a key into a cache. Avoid pointer fields.
+// See resultCacheKey for more.
 type Config struct {
 	Policy                   ReplacementPolicy
-	// If nil, then (i) assume reads & writes will always be in units of pebble sstable
+	// If 0, then (i) assume reads & writes will always be in units of pebble sstable
 	// block size and (ii) do caching in units of pebble sstable blocks.
 	// TODO(josh): I am unsure if the first assumption is okay to make. A related question
 	// I have is whether the existing in-memory pebble block cache caches in units of pebble
 	// sstable blocks.
-	BlockSize                *int64
+	BlockSize                int64
 	CacheSize                int
-	// Must be set if Policy == TinyLFU. Else must be nil.
-	TinyLFUSamples           *int
+	// Must be set >0 if Policy == TinyLFU. Else must be 0.
+	TinyLFUSamples           int
 	WriteThru                bool
 	CacheUserFacingReadsOnly bool
 	L5AndL6Only              bool
+}
+
+func (c *Config) String() string {
+	return fmt.Sprintf("%+v", c)
 }
 
 type Results struct {
@@ -40,7 +60,103 @@ type Results struct {
 	Misses int
 }
 
-type Cache interface {
+func Simulate(traceID string, it iterator, config Config) (*Results, error) {
+	if config.Policy == S4LRU {
+		// Requires that size is divisible by four. Must adjust before
+		// interacting with the cache.
+		config.CacheSize = config.CacheSize / 4 * 4
+	}
+
+	results, ok := resultCache[resultCacheKey{
+		traceID: traceID,
+		config:  config,
+	}]
+	if ok {
+		return &results, nil
+	}
+
+	results = Results{}
+	var cache cache
+	if config.Policy == ClockPro {
+		cache = clockpro.New(config.CacheSize)
+	} else if config.Policy == S4LRU {
+		cache = &wrappedS4LRU{s4lru.New(config.CacheSize)}
+	} else if config.Policy == TinyLFU {
+		if config.TinyLFUSamples == 0 {
+			panic("samples expected to be set but not set")
+		}
+		cache = &wrappedTinyLFU{tinylfu.New(config.CacheSize, config.TinyLFUSamples)}
+	} else {
+		panic("replacement policy not implemented")
+	}
+	if config.Policy != TinyLFU && config.TinyLFUSamples != 0 {
+		panic("sampled expected to not be set (set to 0) but is set")
+	}
+
+	for {
+		trace, err := it.NextBatch()
+		if err != nil {
+			return nil, err
+		}
+		if trace == nil {
+			break
+		}
+
+		for _, e := range trace {
+			if config.L5AndL6Only {
+				if e.LevelPlusOne <= 5 {
+					continue
+				}
+			}
+			// TODO(josh): We may want to ignore RecordCacheHitOps, or at least
+			// not call Set when they come up. Some discussion about this is at
+			// https://github.com/RaduBerinde/pebble_analysis/pull/1#discussion_r1158823825
+			if e.Op == objiotracing.ReadOp || e.Op == objiotracing.RecordCacheHitOp {
+				if config.CacheUserFacingReadsOnly {
+					if e.Reason != objiotracing.UnknownReason {
+						continue
+					}
+				}
+				offset := e.Offset
+				if config.BlockSize != 0 {
+					// TODO(josh): The end of a read may hit a different "cache block" than
+					// the start of a read. This code currently only simulates reading the
+					// first "cache block".
+					offset = offset / config.BlockSize
+				}
+				k := fmt.Sprintf("%v/%v", e.FileNum, offset)
+				v := cache.Get(k)
+				if v == nil {
+					results.Misses++
+					cache.Set(k, true)
+				} else  {
+					results.Hits++
+				}
+			}
+			if config.WriteThru {
+				if e.Op == objiotracing.WriteOp {
+					// TODO(josh): The end of a write may hit a different "cache block" than
+					// the start of a write. This code currently only simulates writing the
+					// first "cache block" out.
+					offset := e.Offset
+					if config.BlockSize != 0 {
+						offset = offset / config.BlockSize
+					}
+					k := fmt.Sprintf("%v/%v", e.FileNum, e.Offset)
+					cache.Set(k, true)
+				}
+			}
+		}
+	}
+
+	resultCache[resultCacheKey{
+		traceID: traceID,
+		config:  config,
+	}] = results
+	return &results, nil
+}
+
+type cache interface {
 	Get(key string) interface{}
 	Set(key string, value interface{})
 }
@@ -77,67 +193,17 @@ func (c *wrappedTinyLFU) Set(key string, value interface{}) {
 	c.c.Add(key, value)
 }
 
-func Simulate(trace []objiotracing.Event, config Config) Results {
-	var results Results
-	var cache Cache
-	if config.Policy == ClockPro {
-		cache = clockpro.New(config.CacheSize)
-	} else if config.Policy == S4LRU {
-		cache = &wrappedS4LRU{s4lru.New(config.CacheSize)}
-	} else if config.Policy == TinyLFU {
-		if config.TinyLFUSamples == nil {
-			panic("samples expected to be set but not set")
-		}
-		cache = &wrappedTinyLFU{tinylfu.New(config.CacheSize, *config.TinyLFUSamples)}
-	} else {
-		panic("replacement policy not implemented")
-	}
-	if config.Policy != TinyLFU && config.TinyLFUSamples != nil {
-		panic("sampled expected to not be set but is set")
-	}
-
-	for _, e := range trace {
-		if config.L5AndL6Only {
-			if e.LevelPlusOne <= 5 {
-				continue
-			}
-		}
-		if e.Op == objiotracing.ReadOp || e.Op == objiotracing.RecordCacheHitOp {
-			if config.CacheUserFacingReadsOnly {
-				if e.Reason != objiotracing.UnknownReason {
-					continue
-				}
-			}
-			offset := e.Offset
-			if config.BlockSize != nil {
-				// TODO(josh): The end of a read may hit a different "cache block" than
-				// the start of a read. This code currently only simulates reading the
-				// first "cache block".
-				offset = offset / *config.BlockSize
-			}
-			k := fmt.Sprintf("%v/%v", e.FileNum, offset)
-			v := cache.Get(k)
-			if v == nil {
-				results.Misses++
-				cache.Set(k, true)
-			} else  {
-				results.Hits++
-			}
-		}
-		if config.WriteThru {
-			if e.Op == objiotracing.WriteOp {
-				// TODO(josh): The end of a write may hit a different "cache block" than
-				// the start of a write. This code currently only simulates writing the
-				// first "cache block" out.
-				offset := e.Offset
-				if config.BlockSize != nil {
-					offset = offset / *config.BlockSize
-				}
-				k := fmt.Sprintf("%v/%v", e.FileNum, e.Offset)
-				cache.Set(k, true)
-			}
-		}
-	}
-
-	return results
+type iterator interface {
+	NextBatch() ([]objiotracing.Event, error)
 }
+
+// TODO(josh): Make caching persistent instead of in-memory.
+// TODO(josh): Enable adding new options to Config without
+// needing to clear out caches.
+type resultCacheKey struct {
+	traceID string
+	config  Config
+}
+
+var resultCache = map[resultCacheKey]Results{}
+


### PR DESCRIPTION
I will take a few "interesting" traces on `roachprod` clusters ~now & start poking at them. I want to do this to make sure that changes I make to this repo are guided by our goal of achieving a high cache hit rate on realistic workloads, etc.

<img width="2560" alt="image" src="https://user-images.githubusercontent.com/1443719/230482476-fb071995-cdad-45f7-b5f3-b32c67af5b72.png">
